### PR TITLE
Implemented the Player Faction Reputation Logic.

### DIFF
--- a/NinjectWarrior/Data/main_quest.json
+++ b/NinjectWarrior/Data/main_quest.json
@@ -17,6 +17,10 @@
     "extra": {
       "companion": "Kaelin",
       "craftingOutcome": "Iron Sword → Thundercleaver (Strength +12)"
+    },
+    "factionImpact": {
+      "cityRogues": 0,
+      "emberforgedGuild": 0
     }
   },
   {
@@ -36,6 +40,10 @@
     "puzzleId": "catacomb_switches",
     "extra": {
       "craftingOutcome": "Unstable Embercore → Firebomb Flask (AoE Burn)"
+    },
+    "factionImpact": {
+      "cityRogues": 10,
+      "emberforgedGuild": -5
     }
   },
   {
@@ -53,7 +61,11 @@
     },
     "battle": "Frost-Maddened Wyrm",
     "puzzleId": "frozen_runestones",
-    "extra": null
+    "extra": null,
+    "factionImpact": {
+      "cityRogues": 0,
+      "emberforgedGuild": 0
+    }
   },
   {
     "Id": "4",
@@ -72,6 +84,10 @@
     "puzzleId": "council_sigil_grid",
     "extra": {
       "companion": "Council Spirit (temporary aid in battles)"
+    },
+    "factionImpact": {
+      "cityRogues": 0,
+      "emberforgedGuild": 0
     }
   },
   {
@@ -91,6 +107,10 @@
     "puzzleId": "final_alignment",
     "extra": {
       "endingVariant": "Determined by accumulated faction points"
+    },
+    "factionImpact": {
+      "cityRogues": 0,
+      "emberforgedGuild": 0
     }
   }
 ]

--- a/NinjectWarrior/Models/Quest.cs
+++ b/NinjectWarrior/Models/Quest.cs
@@ -26,7 +26,7 @@ namespace NinjectWarrior.Models
 
     public class FactionImpact
     {
-        public int Rogue { get; set; }
-        public int Guild { get; set; }
+        public int CityRogues { get; set; }
+        public int EmberforgedGuild { get; set; }
     }
 }

--- a/NinjectWarrior/Services/StoryService.cs
+++ b/NinjectWarrior/Services/StoryService.cs
@@ -46,6 +46,12 @@ namespace NinjectWarrior.Services
                 }
             }
 
+            if (quest.FactionImpact != null)
+            {
+                UpdateFactionReputation(player, Faction.EmberforgedGuild, quest.FactionImpact.EmberforgedGuild);
+                UpdateFactionReputation(player, Faction.CityRogues, quest.FactionImpact.CityRogues);
+            }
+
             player.CompletedQuestIds.Add(questId);
             player.ActiveQuestId = null;
 
@@ -83,6 +89,26 @@ namespace NinjectWarrior.Services
             else
             {
                 player.CurrentGameState = GameState.Adventure;
+            }
+        }
+
+        private void UpdateFactionReputation(Player player, Faction faction, int reputationChange)
+        {
+            if (reputationChange == 0) return;
+
+            var playerFaction = player.PlayerFactions.FirstOrDefault(f => f.Faction == faction);
+            if (playerFaction != null)
+            {
+                playerFaction.Reputation += reputationChange;
+            }
+            else
+            {
+                player.PlayerFactions.Add(new PlayerFaction
+                {
+                    PlayerId = player.Id,
+                    Faction = faction,
+                    Reputation = reputationChange
+                });
             }
         }
     }


### PR DESCRIPTION
Introduced the logic for tracking and updating player reputation with different factions based on quest completion. Here's what I did:

- added `factionImpact` data to `main_quest.json` to define reputation changes for each quest.
- updated `StoryService` to process the `factionImpact` data. When a quest is completed, the service now updates the player's reputation with the relevant factions.
- ensured consistency between the JSON data, C# models (`Quest`, `FactionImpact`), and the `Faction` enum.