### PR TITLE
fix: Correct puzzle initiation timing for quests

### DIFF
--- a/NinjectWarrior/Services/StoryService.cs
+++ b/NinjectWarrior/Services/StoryService.cs
@@ -15,12 +15,19 @@ namespace NinjectWarrior.Services
                 if (firstQuest != null)
                 {
                     player.CurrentMainQuestId = firstQuest.Id;
-					InitiateQuestSequence(player, firstQuest);
-                    return firstQuest;
                 }
-                return null;
+                else
+                {
+                    return null;
+                }
             }
-            return _questRepository.GetQuest(player.CurrentMainQuestId);
+
+            var quest = _questRepository.GetQuest(player.CurrentMainQuestId);
+            if (quest != null && player.ActiveQuestId != quest.Id && !player.CompletedQuestIds.Contains(quest.Id))
+            {
+                InitiateQuestSequence(player, quest);
+            }
+            return quest;
         }
 
         public IEnumerable<Quest> GetAvailableSubQuests(Player player)
@@ -93,7 +100,7 @@ namespace NinjectWarrior.Services
             if (nextQuest != null && nextQuest.QuestType == QuestType.Main)
             {
                 player.CurrentMainQuestId = nextQuest.Id;
-                InitiateQuestSequence(player, nextQuest);
+                //InitiateQuestSequence(player, nextQuest);
             }
             else
             {


### PR DESCRIPTION
The puzzle for the next quest was being shown instead of the puzzle for the current quest. This was because the quest initiation logic (which sets up the puzzle) was being called when advancing to the next quest, rather than when the current quest becomes active.

This commit refactors the `StoryService` to correct this timing.
- The `InitiateQuestSequence` method is no longer called from `AdvanceToNextMainQuest`.
- The `GetCurrentMainQuest` method now checks if the current quest has been initiated and calls `InitiateQuestSequence` if it hasn't.

This ensures that the puzzle displayed to you correctly matches the active quest.