### PR TITLE
test: Verify puzzle is linked to the correct quest

### DIFF
--- a/NinjectWarrior.Tests/StoryServiceTests.cs
+++ b/NinjectWarrior.Tests/StoryServiceTests.cs
@@ -50,5 +50,32 @@ namespace NinjectWarrior.Tests
             Assert.NotNull(rogueFaction);
             Assert.Equal(-5, rogueFaction.Reputation);
         }
+
+        [Fact]
+        public void GetCurrentMainQuest_InitiatesPuzzle_ForCurrentQuest()
+        {
+            // Arrange
+            var player = new Player
+            {
+                Id = 1,
+                CurrentMainQuestId = "1"
+            };
+
+            var quest1 = new Quest { Id = "1", PuzzleId = "puzzle_1" };
+            var quest2 = new Quest { Id = "2", PuzzleId = "puzzle_2" };
+
+            var mockQuestRepository = new Mock<IQuestRepository>();
+            mockQuestRepository.Setup(repo => repo.GetQuest("1")).Returns(quest1);
+            mockQuestRepository.Setup(repo => repo.GetQuest("2")).Returns(quest2);
+
+            var storyService = new StoryService(mockQuestRepository.Object);
+
+            // Act
+            storyService.GetCurrentMainQuest(player);
+
+            // Assert
+            Assert.Equal("puzzle_1", player.ActivePuzzleId);
+            Assert.Equal(GameState.Puzzle, player.CurrentGameState);
+        }
     }
 }


### PR DESCRIPTION
Adds a new unit test to `StoryServiceTests.cs`.

The test `GetCurrentMainQuest_InitiatesPuzzle_ForCurrentQuest` is added to ensure that when a quest becomes active, the puzzle initiated is the one that belongs to that specific quest.

This verifies the fix for the bug where the puzzle of the *next* quest was being displayed and helps protect against regressions.